### PR TITLE
fix: suppress callback_t converting warning

### DIFF
--- a/fw/Core/Hitcon/App/BadUsbApp.cc
+++ b/fw/Core/Hitcon/App/BadUsbApp.cc
@@ -11,8 +11,11 @@ BadUsbApp::BadUsbApp() {}
 
 void BadUsbApp::OnEntry() {
   _skip_crc = false;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_usb_logic.RunScript((callback_t)&BadUsbApp::OnScriptFinished, this,
                         (callback_t)&BadUsbApp::OnScriptError, this, true);
+#pragma GCC diagnostic pop
 }
 
 void BadUsbApp::OnExit() { g_usb_logic.StopScript(); }
@@ -24,9 +27,12 @@ void BadUsbApp::OnButton(button_t button) {
       break;
     case BUTTON_OK:
       if (_skip_crc) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
         g_usb_logic.RunScript((callback_t)&BadUsbApp::OnScriptFinished, this,
                               (callback_t)&BadUsbApp::OnScriptError, this,
                               false);
+#pragma GCC diagnostic pop
       }
       break;
   }

--- a/fw/Core/Hitcon/App/BouncingDVDApp.cc
+++ b/fw/Core/Hitcon/App/BouncingDVDApp.cc
@@ -82,6 +82,8 @@ using hitcon::service::sched::task_callback_t;
 
 unsigned bouncing_dvd_rand() { return g_fast_random_pool.GetRandom(); }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 BouncingDVDApp::BouncingDVDApp()
     : bouncing_dvd(bouncing_dvd_rand),
       periodic_task(UPDATE_PRIORITY,
@@ -89,6 +91,7 @@ BouncingDVDApp::BouncingDVDApp()
                     this, UPDATE_INTERVAL) {
   hitcon::service::sched::scheduler.Queue(&periodic_task, nullptr);
 }
+#pragma GCC diagnostic pop
 
 void BouncingDVDApp::OnEntry() {
   display_set_orientation(0);

--- a/fw/Core/Hitcon/App/DebugApp.cc
+++ b/fw/Core/Hitcon/App/DebugApp.cc
@@ -22,9 +22,12 @@ DebugAccelApp g_debug_accel_app;
 IrRetxDebugApp g_ir_retx_debug_app;
 DebugApp g_debug_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 DebugAccelApp::DebugAccelApp()
     : main_task_(850, (task_callback_t)&DebugAccelApp::MainTaskFn, this, 800),
       main_task_scheduled_(false) {}
+#pragma GCC diagnostic pop
 
 void DebugAccelApp::OnEntry() {
   running_ = true;

--- a/fw/Core/Hitcon/App/DinoApp.cc
+++ b/fw/Core/Hitcon/App/DinoApp.cc
@@ -22,9 +22,12 @@ int combo_button_ctr = 0;
 
 DinoApp dino_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 DinoApp::DinoApp()
     : _routine_task(930, (task_callback_t)&DinoApp::Routine, (void*)this,
                     INTERVAL) {}
+#pragma GCC diagnostic pop
 
 void DinoApp::Init() { scheduler.Queue(&_routine_task, nullptr); }
 

--- a/fw/Core/Hitcon/App/HardwareTestApp.cc
+++ b/fw/Core/Hitcon/App/HardwareTestApp.cc
@@ -16,9 +16,12 @@ using namespace hitcon::ir;
 
 namespace hitcon {
 HardwareTestApp hardware_test_app;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 HardwareTestApp::HardwareTestApp()
     : task(30, (task_callback_t)&HardwareTestApp::Routine, (void*)this,
            PERIOD / 5) {}
+#pragma GCC diagnostic pop
 
 constexpr uint8_t _xboard_data[] = {'T', 'U', 'Z', 'K', 'I'};
 constexpr uint8_t _xboard_data_len = sizeof(_xboard_data) / sizeof(uint8_t);
@@ -37,8 +40,11 @@ void HardwareTestApp::CheckXBoard(void* arg1) {
 
 void HardwareTestApp::Init() {
   scheduler.Queue(&task, nullptr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_xboard_logic.SetOnPacketArrive((callback_t)&HardwareTestApp::CheckXBoard,
                                    this, TEST_APP_RECV_ID);
+#pragma GCC diagnostic pop
 }
 
 void HardwareTestApp::CheckIr(void* arg1) {
@@ -64,7 +70,10 @@ void HardwareTestApp::CheckImu(void* arg) {
     return;
   }
   if (current_state == TS_GYRO) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
     g_imu_logic.AccSelfTest((callback_t)&HardwareTestApp::CheckImu, this);
+#pragma GCC diagnostic pop
     next_state = TS_ACC;
   } else if (current_state == TS_ACC)
     next_state = TS_PASS;
@@ -145,7 +154,10 @@ void HardwareTestApp::OnButton(button_t button) {
     case TS_GYRO:
       if (button == BUTTON_OK) {
         HAL_Delay(500);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
         g_imu_logic.GyroSelfTest((callback_t)&HardwareTestApp::CheckImu, this);
+#pragma GCC diagnostic pop
       }
       break;
   }

--- a/fw/Core/Hitcon/App/IrForceRetxApp.cc
+++ b/fw/Core/Hitcon/App/IrForceRetxApp.cc
@@ -9,9 +9,12 @@ namespace hitcon {
 
 IrForceRetxApp g_ir_force_retx_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 IrForceRetxApp::IrForceRetxApp()
     : routine_task_(950, (callback_t)&IrForceRetxApp::RoutineTask, this, 500),
       state_(0) {}
+#pragma GCC diagnostic pop
 
 void IrForceRetxApp::OnEntry() {
   state_ = 1;

--- a/fw/Core/Hitcon/App/MultiplayerGame.cc
+++ b/fw/Core/Hitcon/App/MultiplayerGame.cc
@@ -113,8 +113,11 @@ void MultiplayerGame::SendAttack(uint8_t atk) {
 
 void MultiplayerGame::OnEntry() {
   GameEntry();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_xboard_logic.SetOnPacketArrive((callback_t)&MultiplayerGame::OnXboardRecv,
                                    this, GetXboardRecvId());
+#pragma GCC diagnostic pop
 }
 
 void MultiplayerGame::OnExit() { GameExit(); }

--- a/fw/Core/Hitcon/App/ShowIdApp.h
+++ b/fw/Core/Hitcon/App/ShowIdApp.h
@@ -8,12 +8,15 @@
 namespace hitcon {
 class ShowIdApp : public App {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   ShowIdApp()
       : _get_id_task(900, (service::sched::task_callback_t)&ShowIdApp::GetId,
                      this, 50000),
         _type_id_task(
             810, (service::sched::task_callback_t)&ShowIdApp::TypeIdRoutine,
             this, 20) {}
+#pragma GCC diagnostic pop
   virtual ~ShowIdApp() = default;
 
   void Init();

--- a/fw/Core/Hitcon/App/ShowNameApp.cc
+++ b/fw/Core/Hitcon/App/ShowNameApp.cc
@@ -30,9 +30,12 @@ static constexpr unsigned SURPRISE_TIME = 10 * 1000;
 }  // namespace
 ShowNameApp show_name_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 ShowNameApp::ShowNameApp()
     : _routine_task(490, (task_callback_t)&ShowNameApp::check_update, this,
                     1000) {}
+#pragma GCC diagnostic pop
 
 void ShowNameApp::Init() {
   nv_storage_content &content = g_nv_storage.GetCurrentStorage();

--- a/fw/Core/Hitcon/App/SnakeApp.cc
+++ b/fw/Core/Hitcon/App/SnakeApp.cc
@@ -22,9 +22,12 @@ namespace snake {
 
 SnakeApp snake_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 SnakeApp::SnakeApp()
     : _routine_task(30, (task_callback_t)&SnakeApp::Routine, (void*)this,
                     INTERVAL) {}
+#pragma GCC diagnostic pop
 
 /* TODO:
  *  3. event when _len = 128

--- a/fw/Core/Hitcon/App/TetrisApp.cc
+++ b/fw/Core/Hitcon/App/TetrisApp.cc
@@ -35,12 +35,15 @@ unsigned int tetris_random() { return g_fast_random_pool.GetRandom(); }
 
 TetrisApp tetris_app;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 TetrisApp::TetrisApp()
     : periodic_task(hitcon::tetris::UPDATE_PRIORITY,
                     (task_callback_t)&TetrisApp::periodic_task_callback, this,
                     hitcon::tetris::UPDATE_INTERVAL) {
   hitcon::service::sched::scheduler.Queue(&periodic_task, nullptr);
 }
+#pragma GCC diagnostic pop
 
 static void SendAttackEnemyPacket(int n_lines) {
   uint8_t data[2] = {XboardPacketType::PACKET_ATTACK, (uint8_t)n_lines};

--- a/fw/Core/Hitcon/Logic/BadgeController.cc
+++ b/fw/Core/Hitcon/Logic/BadgeController.cc
@@ -34,11 +34,16 @@ int combo_button_ctr = 0;
 BadgeController::BadgeController() : current_app(nullptr) {}
 
 void BadgeController::Init() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_button_logic.SetCallback((callback_t)&BadgeController::OnButton, this);
   g_button_logic.SetEdgeCallback((callback_t)&BadgeController::OnEdgeButton,
                                  this);
+#pragma GCC diagnostic pop
   current_app = &show_name_app;
   current_app->OnEntry();
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   hitcon::service::xboard::g_xboard_logic.SetOnConnectPeer2025(
       (callback_t)&BadgeController::OnXBoardConnect, this);
   hitcon::service::xboard::g_xboard_logic.SetOnDisconnectPeer2025(
@@ -58,6 +63,7 @@ void BadgeController::Init() {
                                     this);
   usb::g_usb_service.SetOnUsbPlugOut((callback_t)&BadgeController::OnUsbPlugOut,
                                      this);
+#pragma GCC diagnostic pop
 }
 
 void BadgeController::SetCallback(callback_t callback, void *callback_arg1,

--- a/fw/Core/Hitcon/Logic/ButtonLogic.cc
+++ b/fw/Core/Hitcon/Logic/ButtonLogic.cc
@@ -8,14 +8,20 @@ using namespace hitcon::service::sched;
 namespace hitcon {
 ButtonLogic g_button_logic;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 ButtonLogic::ButtonLogic()
     : _callback_task(642, (callback_t)&ButtonLogic::CallbackWrapper, this),
       _edge_callback_task(643, (callback_t)&ButtonLogic::EdgeCallbackWrapper,
                           this) {}
+#pragma GCC diagnostic pop
 
 void ButtonLogic::Init() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_button_service.SetDataInCallback((callback_t)&ButtonLogic::OnReceiveData,
                                      this);
+#pragma GCC diagnostic pop
   for (uint8_t i = 0; i < BUTTON_AMOUNT; i++) {
     _count[i] = 0;
     _edge_flag[i] = 0;

--- a/fw/Core/Hitcon/Logic/DisplayLogic.cc
+++ b/fw/Core/Hitcon/Logic/DisplayLogic.cc
@@ -7,13 +7,19 @@ using namespace hitcon::service::sched;
 namespace hitcon {
 DisplayLogic g_display_logic;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 DisplayLogic::DisplayLogic()
     : task(170, (task_callback_t)&DisplayLogic::HandlePopulate, (void*)this) {}
+#pragma GCC diagnostic pop
 
 void DisplayLogic::Init() {
   // TODO: Verify this.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_display_service.SetRequestFrameCallback(
       (callback_t)&DisplayLogic::OnRequestFrame, this);
+#pragma GCC diagnostic pop
   frame_ = 0;
 }
 

--- a/fw/Core/Hitcon/Logic/EntropyHub.cc
+++ b/fw/Core/Hitcon/Logic/EntropyHub.cc
@@ -19,9 +19,12 @@ constexpr size_t kMaxAdcSeedCount = 32;
 
 }  // namespace
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 EntropyHub::EntropyHub()
     : routine_task(980, (task_callback_t)&EntropyHub::Routine, this, 100),
       state(0), last_sched_tasks(0), random_ready(false) {}
+#pragma GCC diagnostic pop
 
 void EntropyHub::AcceptNoiseFromSource(void* arg1) {
   if (adc_seed_count >= kMaxAdcSeedCount) return;
@@ -45,8 +48,11 @@ void EntropyHub::Init() {
   hitcon::service::sched::scheduler.Queue(&routine_task, nullptr);
   hitcon::service::sched::scheduler.EnablePeriodic(&routine_task);
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_noise_source.SetOnNoiseBytes(
       (task_callback_t)&EntropyHub::AcceptNoiseFromSource, this);
+#pragma GCC diagnostic pop
 }
 
 bool EntropyHub::EntropyReady() { return random_ready; }

--- a/fw/Core/Hitcon/Logic/GameController.cc
+++ b/fw/Core/Hitcon/Logic/GameController.cc
@@ -16,10 +16,13 @@ hitcon::game::GameController g_game_controller;
 
 namespace game {
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 GameController::GameController()
     : state_(0), pubAnnounceCnt(kPubAnnounceCycleInterval - 2),
       pubAnnounceTask(960, (callback_t)&GameController::TrySendPubAnnounce,
                       this, 1490) {}
+#pragma GCC diagnostic pop
 
 void GameController::Init() {
   hitcon::ecc::g_ec_logic.SetPrivateKey(g_per_board_data.GetPrivKey());

--- a/fw/Core/Hitcon/Logic/GameScore.cc
+++ b/fw/Core/Hitcon/Logic/GameScore.cc
@@ -21,9 +21,12 @@ constexpr int kBusyRoutineDelay = 100;
 
 }  // namespace
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 GameScore::GameScore()
     : routine_task_delayed(920, (callback_t)&GameScore::Routine, this, 0),
       nv_fetched_(false) {}
+#pragma GCC diagnostic pop
 
 void GameScore::Init() {
   last_operation_progress_ = 0;

--- a/fw/Core/Hitcon/Logic/ImuLogic.cc
+++ b/fw/Core/Hitcon/Logic/ImuLogic.cc
@@ -14,17 +14,23 @@ namespace hitcon {
 
 ImuLogic g_imu_logic;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 ImuLogic::ImuLogic()
     : _routine_task(419, (task_callback_t)&ImuLogic::Routine, (void*)this,
                     ROUTINE_INTERVAL),
       _proximity_task(420, (task_callback_t)&ImuLogic::ProximityRoutine,
                       (void*)this, PROXIMITY_INTERVAL),
       _state(RoutineState::INIT), _init_state(InitState::CHECK_ID), _step(0) {}
+#pragma GCC diagnostic pop
 
 void ImuLogic::Init() {
 #ifndef DUMMY_STEP
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_imu_service.SetRxCallback((callback_t)&ImuLogic::OnRxDone, this);
   g_imu_service.SetTxCallback((callback_t)&ImuLogic::OnTxDone, this);
+#pragma GCC diagnostic pop
   _start_time = SysTimer::GetTime();
 #else
   _state = RoutineState::DUMMY;

--- a/fw/Core/Hitcon/Logic/IrController.cc
+++ b/fw/Core/Hitcon/Logic/IrController.cc
@@ -31,10 +31,13 @@ static char SURPRISE_NAME[] = "You got pwned!";
 
 IrController irController;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 IrController::IrController()
     : routine_task(950, (callback_t)&IrController::RoutineTask, this, 1000),
       showtext_task(800, (callback_t)&IrController::ShowText, this),
       broadcast_task(800, (callback_t)&IrController::BroadcastIr, this) {}
+#pragma GCC diagnostic pop
 
 void IrController::ShowText(void* arg) {
   struct ShowPacket* pkt = reinterpret_cast<struct ShowPacket*>(arg);
@@ -45,10 +48,13 @@ void IrController::ShowText(void* arg) {
 }
 
 void IrController::Init() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   irLogic.SetOnPacketReceived((callback_t)&IrController::OnPacketReceived,
                               this);
   badge_controller.SetCallback((callback_t)&IrController::SendShowPacket, this,
                                SURPRISE_NAME);
+#pragma GCC diagnostic pop
   scheduler.Queue(&routine_task, nullptr);
   scheduler.EnablePeriodic(&routine_task);
 }
@@ -185,9 +191,12 @@ void IrController::MaintainQueued() {
       // Waiting for hash processor to be available.
       if (current_hashing_slot == -1) {
         // Start hashing the payload.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
         bool ret = hitcon::hash::g_hash_service.StartHash(
             pckt_data, pckt_size, (callback_t)&IrController::OnPacketHashResult,
             this);
+#pragma GCC diagnostic pop
         if (ret) {
           // Hashing started successfully. Update status to Waiting for hash
           // processor to finish.

--- a/fw/Core/Hitcon/Logic/IrLogic.cc
+++ b/fw/Core/Hitcon/Logic/IrLogic.cc
@@ -18,16 +18,22 @@ namespace hitcon {
 namespace ir {
 
 IrLogic irLogic;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 service::sched::Task OnBufferReceivedTask(
     490, (service::sched::task_callback_t)&IrLogic::OnBufferReceived, &irLogic);
+#pragma GCC diagnostic pop
 
 IrLogic::IrLogic()
     : lf_total_period(0), lf_nonzero_period(0), lowpass_loadfactor(0) {}
 
 void IrLogic::Init() {
   // Set callback
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   irService.SetOnBufferReceived(
       (callback_t)&IrLogic::OnBufferReceivedEnqueueTask, this);
+#pragma GCC diagnostic pop
 }
 
 size_t packet_buf{0};

--- a/fw/Core/Hitcon/Logic/IrxbBridge.cc
+++ b/fw/Core/Hitcon/Logic/IrxbBridge.cc
@@ -24,15 +24,21 @@ constexpr unsigned kStateInit = 1;
 
 IrxbBridge g_irxb_bridge;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 IrxbBridge::IrxbBridge()
     : routine_task_(950, (callback_t)&IrxbBridge::RoutineTask, this,
                     kIrxbDelayTime),
       state_(0) {}
+#pragma GCC diagnostic pop
 
 void IrxbBridge::Init() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   service::xboard::g_xboard_logic.SetOnPacketArrive(
       (callback_t)&IrxbBridge::OnPacketReceived, this,
       service::xboard::RecvFnId::IR_TO_ATTENDEE);
+#pragma GCC diagnostic pop
 }
 
 void IrxbBridge::OnXBoardBasestnConnect() {

--- a/fw/Core/Hitcon/Logic/NvStorage.cc
+++ b/fw/Core/Hitcon/Logic/NvStorage.cc
@@ -16,8 +16,11 @@ constexpr int kMinFlushInterval = 500;
 
 NvStorage g_nv_storage;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 NvStorage::NvStorage()
     : routine_task(800, (callback_t)&NvStorage::Routine, this, 100) {}
+#pragma GCC diagnostic pop
 
 void NvStorage::Init() {
   int32_t newest_version = -1;

--- a/fw/Core/Hitcon/Logic/RandomPool.cc
+++ b/fw/Core/Hitcon/Logic/RandomPool.cc
@@ -10,10 +10,13 @@ namespace hitcon {
 FastRandomPool g_fast_random_pool;
 SecureRandomPool g_secure_random_pool;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 SecureRandomPool::SecureRandomPool()
     : init_finished(false), seed_count(0),
       routine_task(950, (task_callback_t)&SecureRandomPool::Routine, this, 20) {
 }
+#pragma GCC diagnostic pop
 
 void SecureRandomPool::Init() {
   sha3_Init256(&keccak_context);

--- a/fw/Core/Hitcon/Logic/SponsorReq.cc
+++ b/fw/Core/Hitcon/Logic/SponsorReq.cc
@@ -25,14 +25,20 @@ namespace sponsor {
 
 constexpr int kSponsorReqTaskInterval = 500;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 SponsorReq::SponsorReq()
     : main_task_(850, (task_callback_t)&SponsorReq::RoutineTask, this,
                  kSponsorReqTaskInterval),
       main_task_scheduled_(false) {}
+#pragma GCC diagnostic pop
 
 void SponsorReq::Init() {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_xboard_logic.SetOnPacketArrive(
       (callback_t)&SponsorReq::XBoardResponseHandler, this, SPONSOR_RESP_ID);
+#pragma GCC diagnostic pop
 }
 
 void SponsorReq::OnXBoardConnect() {

--- a/fw/Core/Hitcon/Logic/UsbLogic.cc
+++ b/fw/Core/Hitcon/Logic/UsbLogic.cc
@@ -14,17 +14,23 @@ namespace usb {
 
 UsbLogic g_usb_logic;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 UsbLogic::UsbLogic()
     : _routine_task(810, (task_callback_t)&UsbLogic::Routine, (void*)this,
                     DELAY_INTERVAL),
       _write_routine_task(810, (task_callback_t)&UsbLogic::WriteRoutine,
                           (void*)this, WAIT_INTERVAL) {}
+#pragma GCC diagnostic pop
 
 void UsbLogic::Init() {
   _state = USB_STATE_IDLE;
   scheduler.Queue(&_routine_task, nullptr);
   scheduler.Queue(&_write_routine_task, nullptr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_usb_service.SetOnDataRecv((callback_t)&UsbLogic::OnDataRecv, this);
+#pragma GCC diagnostic pop
 }
 
 // first byte of the report must be CUSTOM_REPORT_ID

--- a/fw/Core/Hitcon/Logic/XBoardLogic.cc
+++ b/fw/Core/Hitcon/Logic/XBoardLogic.cc
@@ -30,18 +30,24 @@ constexpr size_t HEADER_SZ = sizeof(Frame);
 
 // public functions
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 XBoardLogic::XBoardLogic()
     : _parse_routine(490, (task_callback_t)&XBoardLogic::ParseRoutine, this,
                      20),
       _ping_routine(490, (task_callback_t)&XBoardLogic::PingRoutine, this,
                     200) {}
+#pragma GCC diagnostic pop
 
 void XBoardLogic::Init() {
   scheduler.Queue(&_parse_routine, nullptr);
   scheduler.EnablePeriodic(&_parse_routine);
   scheduler.Queue(&_ping_routine, nullptr);
   scheduler.EnablePeriodic(&_ping_routine);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   g_xboard_service.SetOnByteRx((callback_t)&XBoardLogic::OnByteArrive, this);
+#pragma GCC diagnostic pop
 }
 
 void XBoardLogic::QueueDataForTx(const uint8_t *packet, uint8_t packet_len,

--- a/fw/Core/Hitcon/Service/DisplayService.cc
+++ b/fw/Core/Hitcon/Service/DisplayService.cc
@@ -17,9 +17,12 @@ DisplayService g_display_service;
 uint8_t g_display_brightness = 3;
 uint8_t g_display_standby = 0;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 DisplayService::DisplayService()
     : task(169, (task_callback_t)&DisplayService::RequestFrameWrapper,
            (void*)this) {}
+#pragma GCC diagnostic pop
 
 /*
  * DMA Mode: Circular

--- a/fw/Core/Hitcon/Service/FlashService.cc
+++ b/fw/Core/Hitcon/Service/FlashService.cc
@@ -18,8 +18,11 @@ void HAL_FLASH_OperationErrorCallback(uint32_t ReturnValue) {
 namespace hitcon {
 FlashService g_flash_service;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 FlashService::FlashService()
     : routine_task(980, (task_callback_t)&FlashService::Routine, this, 20) {}
+#pragma GCC diagnostic pop
 
 void FlashService::Init() {
   scheduler.Queue(&routine_task, nullptr);

--- a/fw/Core/Hitcon/Service/HashService.cc
+++ b/fw/Core/Hitcon/Service/HashService.cc
@@ -106,8 +106,11 @@ void HashService::doHashDone() {
   scheduler.DisablePeriodic(&hashTask);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 HashService::HashService()
     : hashTask(880, (task_callback_t)&HashService::doHash, (void *)this, 0) {}
+#pragma GCC diagnostic pop
 
 }  // namespace hash
 

--- a/fw/Core/Hitcon/Service/ImuService.cc
+++ b/fw/Core/Hitcon/Service/ImuService.cc
@@ -35,9 +35,12 @@ namespace hitcon {
 
 ImuService g_imu_service;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 ImuService::ImuService()
     : _routine_task(417, (task_callback_t)&ImuService::Routine, this, 100),
       interrupt_task(416, (task_callback_t)&ImuService::I2CCallback, this) {}
+#pragma GCC diagnostic pop
 
 void ImuService::Init() {
 #ifdef DUMMY_STEP

--- a/fw/Core/Hitcon/Service/IrService.cc
+++ b/fw/Core/Hitcon/Service/IrService.cc
@@ -17,6 +17,8 @@ namespace ir {
 
 IrService irService;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 IrService::IrService()
     : dma_tx_populate_task(
           100, (task_callback_t)&IrService::PopulateTxDmaBuffer, this),
@@ -25,6 +27,7 @@ IrService::IrService()
       routine_task(600, (callback_t)&IrService::Routine, this, 22),
       on_rx_callback_runner(500, (callback_t)&IrService::OnBufferRecvWrapper,
                             this) {}
+#pragma GCC diagnostic pop
 
 void ReceiveDmaHalfCplt(DMA_HandleTypeDef *hdma) {
   if (!g_suspender.IsSuspended()) {

--- a/fw/Core/Hitcon/Service/NoiseSource.cc
+++ b/fw/Core/Hitcon/Service/NoiseSource.cc
@@ -7,10 +7,13 @@ using namespace hitcon::service::sched;
 namespace hitcon {
 NoiseSource g_noise_source;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 NoiseSource::NoiseSource()
     : _routine_task(810, (task_callback_t)&NoiseSource::Routine, this,
                     kRoutinePeriod / kNoiseLen),
       _cb_task(805, (task_callback_t)&NoiseSource::CallbackWrapper, this) {}
+#pragma GCC diagnostic pop
 
 void AdcCpltCallback(ADC_HandleTypeDef* hadc) {
   if (hadc == &hadc1) {

--- a/fw/Core/Hitcon/Service/Sched/PeriodicTask.h
+++ b/fw/Core/Hitcon/Service/Sched/PeriodicTask.h
@@ -23,6 +23,8 @@ class PeriodicTask : public DelayedTask {
   void AutoRequeueCb(void *arg);
 
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   // For prio, see Scheduler.h
   constexpr PeriodicTask(unsigned prio, task_callback_t callback, void *thisptr,
                          unsigned interval)
@@ -30,6 +32,7 @@ class PeriodicTask : public DelayedTask {
                     (void *)this, 0),
         enabled(false), interval(interval), savedThisptr(thisptr),
         savedCallback(callback) {}
+#pragma GCC diagnostic pop
 
   virtual ~PeriodicTask();
   void Enable();

--- a/fw/Core/Hitcon/Service/SignedPacketService.cc
+++ b/fw/Core/Hitcon/Service/SignedPacketService.cc
@@ -15,11 +15,14 @@ SignedPacket::SignedPacket() : status(kFree) {}
 
 using namespace hitcon::signed_packet;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 SignedPacketService::SignedPacketService()
     : sigRoutineTask(950, (callback_t)&SignedPacketService::SigRoutineFunc,
                      this, 500),
       verRoutineTask(950, (callback_t)&SignedPacketService::VerRoutineFunc,
                      this, 500) {}
+#pragma GCC diagnostic pop
 
 void SignedPacketService::Init() {
   hitcon::service::sched::scheduler.Queue(&sigRoutineTask, nullptr);
@@ -175,9 +178,12 @@ void SignedPacketService::VerRoutineFunc() {
   if (FindPacketOfState(ver_packet_queue_, PacketStatus::kWaitVerStart,
                         packetId)) {
     SignedPacket &packet = ver_packet_queue_[packetId];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
     bool ret = hitcon::ecc::g_ec_logic.StartVerify(
         packet.data, packet.dataSize, packet.sig,
         (callback_t)&SignedPacketService::OnPacketVerFinish, this);
+#pragma GCC diagnostic pop
     if (ret) {
       packet.status = PacketStatus::kWaitVerDone;
       verifyingPacketId = packetId;
@@ -195,9 +201,12 @@ void SignedPacketService::SigRoutineFunc() {
   if (FindPacketOfState(sig_packet_queue_, PacketStatus::kWaitSignStart,
                         packetId)) {
     SignedPacket &packet = sig_packet_queue_[packetId];
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
     bool ret = hitcon::ecc::g_ec_logic.StartSign(
         packet.data, packet.dataSize,
         (callback_t)&SignedPacketService::OnPacketSignFinish, this);
+#pragma GCC diagnostic pop
     if (ret) {
       packet.status = PacketStatus::kWaitSignDone;
       signingPacketId = packetId;

--- a/fw/Core/Hitcon/Service/UsbService.h
+++ b/fw/Core/Hitcon/Service/UsbService.h
@@ -42,11 +42,14 @@ struct Report {
 
 class UsbService {
  public:
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
   UsbService()
       : interrupt_handler_task(
             808, (task_callback_t)&UsbService::InterruptHandler, (void*)this),
         _retry_task(809, (task_callback_t)&UsbService::RetryHandler,
                     (void*)this, 20) {}
+#pragma GCC diagnostic pop
 
   // set callback when report id 2 is received
   void SetOnReportReceived();

--- a/fw/Core/Hitcon/Service/XBoardService.cc
+++ b/fw/Core/Hitcon/Service/XBoardService.cc
@@ -10,10 +10,13 @@ namespace xboard {
 
 XBoardService g_xboard_service;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpmf-conversions"
 XBoardService::XBoardService()
     : _on_rx_callback(nullptr), _on_rx_callback_arg1(nullptr),
       _rx_task(480, (callback_t)&XBoardService::OnRxWrapper, this),
       _routine_task(490, (task_callback_t)&XBoardService::Routine, this, 10) {}
+#pragma GCC diagnostic pop
 
 void XBoardService::Init() {
   scheduler.Queue(&_routine_task, nullptr);


### PR DESCRIPTION
suppress the warning with
```c
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wpmf-conversions"
#pragma GCC diagnostic pop
```