### PR TITLE
Do not start qte if other is in ending screen

### DIFF
--- a/fw/Core/Hitcon/App/TamaApp.cc
+++ b/fw/Core/Hitcon/App/TamaApp.cc
@@ -714,7 +714,8 @@ void TamaApp::XbUpdateFrameBuffer() {
               : 13);
       break;
     case TAMA_XBOARD_STATE::XBOARD_BATTLE_ENCOUNTER: {
-      if (enemy_packet.state < TAMA_XBOARD_STATE::XBOARD_BATTLE_ENCOUNTER) {
+      if (enemy_packet.state < TAMA_XBOARD_STATE::XBOARD_BATTLE_ENCOUNTER ||
+          enemy_packet.state == TAMA_XBOARD_STATE::XBOARD_BATTLE_END) {
         return;
       }
       const tama_ani_t *me = nullptr, *enemy = nullptr;


### PR DESCRIPTION
Current nvstorage is quite slow. One situation that may encounter is that another person starts a second round but previous winner is still in the ending screen