### PR TITLE
show user name instead of user id on leaderboard

### DIFF
--- a/web/src/app/leaderboard/leaderboard.component.css
+++ b/web/src/app/leaderboard/leaderboard.component.css
@@ -13,6 +13,7 @@
 .leaderboard-response-wrapper {
     min-width: 500px;
     width: 100%;
+    padding: 0px 0px 10px;
 }
 
 .container {
@@ -26,6 +27,7 @@
     padding: 10px;
     border-radius: 15px;
     align-items: center;
+    margin: 3px 0px;
 }
 
 .row-head {

--- a/web/src/app/leaderboard/leaderboard.component.html
+++ b/web/src/app/leaderboard/leaderboard.component.html
@@ -13,7 +13,7 @@
         <div class="leaderboard-response-wrapper">
             <div class="row-head row">
                 <div>Rank</div>
-                <div>User ID</div>
+                <div>Name</div>
                 <div>Score</div>
                 @for (id of sponsorIDs; track $index) {
                 <div class="sponsor-column sponsor-column-header">{{ id }}<span class="tooltip">{{ sponsorNames[id]
@@ -23,7 +23,7 @@
             @for (item of items; track $index ;let rank = $index) {
             <div class="row">
                 <div>{{rank+1}}</div>
-                <div>{{item.player_id | littleEndian}}</div>
+                <div>{{item.name}}</div>
                 <div>{{item.total_score | number}}</div>
                 @for (id of sponsorIDs; track $index) {
                 <div class="sponsor-column" [ngClass]="{'sponsor-column-header': item.connected_sponsors.includes(id)}">

--- a/web/src/app/leaderboard/leaderboard.component.html
+++ b/web/src/app/leaderboard/leaderboard.component.html
@@ -26,8 +26,9 @@
                 <div>{{item.player_id | littleEndian}}</div>
                 <div>{{item.total_score | number}}</div>
                 @for (id of sponsorIDs; track $index) {
-                <div class="sponsor-column">
+                <div class="sponsor-column" [ngClass]="{'sponsor-column-header': item.connected_sponsors.includes(id)}">
                     <div [ngClass]="{'sponsor-column-fill': item.connected_sponsors.includes(id)}"></div>
+                    <span class="tooltip" *ngIf="item.connected_sponsors.includes(id)">{{ sponsorNames[id] }}</span>
                 </div>
                 }
             </div>


### PR DESCRIPTION
原本 show id 現在改成 show name 了

<img width="2048" height="1536" alt="image" src="https://github.com/user-attachments/assets/10268cc2-e563-40b5-a167-d1311817fba7" />
